### PR TITLE
avoid build error when using this lib from another project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ set(INCS "mros2/include"
         ${CMAKE_SOURCE_DIR}/main
         )
 
+if(NOT CMAKE_BUILD_EARLY_EXPANSION)
+        add_compile_options(-w)
+endif()
+
 idf_component_register(
         SRCS ${SRCS}
         INCLUDE_DIRS ${INCS}

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ idf.py build
 When the build completed successfully, a binary is generated in `build/echoback_string.bin`.
 
 Connect the device to the host via USB cable, and flash the binary to it.
-The default port in Ubuntu may be `/tty/ttyUSB0``, but you may need to change it according to your environment.
+The port `/tty/ttyUSB0` may be adjusted according to your target board and development environment.
 
 ```
 idf.py -p /tty/ttyUSB0 flash
@@ -262,6 +262,7 @@ You need to edit `./CMakeLists.txt` and `./main/CMakeLists.txt` as the below.
   include($ENV{IDF_PATH}/tools/cmake/project.cmake)
   project(hello_mros2)
   ```
+  - This is due to avoid build error about `-Werror=format` in mros2-esp32 logging functions. See [#Issue16](https://github.com/mROS-base/mros2-esp32/issues/16) for details.
 - `./main/CMakeLists.txt`
   ```
   idf_component_register(SRCS "hello_mros2.cpp"  # edit


### PR DESCRIPTION
relate to https://github.com/mROS-base/mros2-esp32/issues/16 and https://github.com/mROS-base/rcjp2023_mros2/issues/12