### PR TITLE
Adding examples/ethernet/basic, support mros2-esp32

### DIFF
--- a/platform/ethernet/CMakeLists.txt
+++ b/platform/ethernet/CMakeLists.txt
@@ -1,0 +1,8 @@
+# The following lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+# "Trim" the build. Include the minimal set of components, main, and anything it depends on.
+idf_build_set_property(MINIMAL_BUILD ON)
+project(ethernet_basic)

--- a/platform/ethernet/components/ethernet_init/CMakeLists.txt
+++ b/platform/ethernet/components/ethernet_init/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "ethernet_init.c"
+                       PRIV_REQUIRES esp_driver_gpio esp_eth
+                       INCLUDE_DIRS ".")

--- a/platform/ethernet/components/ethernet_init/ethernet_init.c
+++ b/platform/ethernet/components/ethernet_init/ethernet_init.c
@@ -1,0 +1,346 @@
+/*
+ * NOTE:
+ *   This file is copied from esp-idf examples as the below, and modified for usage of mros2-esp32.
+ *   https://github.com/espressif/esp-idf/blob/master/examples/ethernet/basic/components/ethernet_init/ethernet_init.c
+ *   Therefore, mROS-base org inherits the Public Domain (or CC0) LICENCE for this file from the original file.
+ */
+/*
+ * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Unlicense OR CC0-1.0
+ */
+#include "ethernet_init.h"
+#include "esp_log.h"
+#include "esp_check.h"
+#include "esp_mac.h"
+#include "driver/gpio.h"
+#include "sdkconfig.h"
+#if CONFIG_EXAMPLE_USE_SPI_ETHERNET
+#include "driver/spi_master.h"
+#endif // CONFIG_EXAMPLE_USE_SPI_ETHERNET
+
+#if CONFIG_EXAMPLE_SPI_ETHERNETS_NUM
+#define SPI_ETHERNETS_NUM           CONFIG_EXAMPLE_SPI_ETHERNETS_NUM
+#else
+#define SPI_ETHERNETS_NUM           0
+#endif
+
+#if CONFIG_EXAMPLE_USE_INTERNAL_ETHERNET
+#define INTERNAL_ETHERNETS_NUM      1
+#else
+#define INTERNAL_ETHERNETS_NUM      0
+#endif
+
+#define INIT_SPI_ETH_MODULE_CONFIG(eth_module_config, num)                                      \
+    do {                                                                                        \
+        eth_module_config[num].spi_cs_gpio = CONFIG_EXAMPLE_ETH_SPI_CS ##num## _GPIO;           \
+        eth_module_config[num].int_gpio = CONFIG_EXAMPLE_ETH_SPI_INT ##num## _GPIO;             \
+        eth_module_config[num].polling_ms = CONFIG_EXAMPLE_ETH_SPI_POLLING ##num## _MS;         \
+        eth_module_config[num].phy_reset_gpio = CONFIG_EXAMPLE_ETH_SPI_PHY_RST ##num## _GPIO;   \
+        eth_module_config[num].phy_addr = CONFIG_EXAMPLE_ETH_SPI_PHY_ADDR ##num;                \
+    } while(0)
+
+typedef struct {
+    uint8_t spi_cs_gpio;
+    int8_t int_gpio;
+    uint32_t polling_ms;
+    int8_t phy_reset_gpio;
+    uint8_t phy_addr;
+    uint8_t *mac_addr;
+}spi_eth_module_config_t;
+
+static const char *TAG = "example_eth_init";
+#if CONFIG_EXAMPLE_USE_SPI_ETHERNET
+static bool gpio_isr_svc_init_by_eth = false; // indicates that we initialized the GPIO ISR service
+#endif // CONFIG_EXAMPLE_USE_SPI_ETHERNET
+
+
+#if CONFIG_EXAMPLE_USE_INTERNAL_ETHERNET
+/**
+ * @brief Internal ESP32 Ethernet initialization
+ *
+ * @param[out] mac_out optionally returns Ethernet MAC object
+ * @param[out] phy_out optionally returns Ethernet PHY object
+ * @return
+ *          - esp_eth_handle_t if init succeeded
+ *          - NULL if init failed
+ */
+static esp_eth_handle_t eth_init_internal(esp_eth_mac_t **mac_out, esp_eth_phy_t **phy_out)
+{
+    esp_eth_handle_t ret = NULL;
+
+    // Init common MAC and PHY configs to default
+    eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+    eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
+
+    // Update PHY config based on board specific configuration
+    phy_config.phy_addr = CONFIG_EXAMPLE_ETH_PHY_ADDR;
+    phy_config.reset_gpio_num = CONFIG_EXAMPLE_ETH_PHY_RST_GPIO;
+    // Init vendor specific MAC config to default
+    eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
+    // Update vendor specific MAC config based on board configuration
+    esp32_emac_config.smi_gpio.mdc_num = CONFIG_EXAMPLE_ETH_MDC_GPIO;
+    esp32_emac_config.smi_gpio.mdio_num = CONFIG_EXAMPLE_ETH_MDIO_GPIO;
+#if CONFIG_EXAMPLE_USE_SPI_ETHERNET
+    // The DMA is shared resource between EMAC and the SPI. Therefore, adjust
+    // EMAC DMA burst length when SPI Ethernet is used along with EMAC.
+    esp32_emac_config.dma_burst_len = ETH_DMA_BURST_LEN_4;
+#endif // CONFIG_EXAMPLE_USE_SPI_ETHERNET
+    // Create new ESP32 Ethernet MAC instance
+    esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
+    // Create new PHY instance based on board configuration
+#if CONFIG_EXAMPLE_ETH_PHY_GENERIC
+    esp_eth_phy_t *phy = esp_eth_phy_new_generic(&phy_config);
+#elif CONFIG_EXAMPLE_ETH_PHY_IP101
+    esp_eth_phy_t *phy = esp_eth_phy_new_ip101(&phy_config);
+#elif CONFIG_EXAMPLE_ETH_PHY_RTL8201
+    esp_eth_phy_t *phy = esp_eth_phy_new_rtl8201(&phy_config);
+#elif CONFIG_EXAMPLE_ETH_PHY_LAN87XX
+    esp_eth_phy_t *phy = esp_eth_phy_new_lan87xx(&phy_config);
+#elif CONFIG_EXAMPLE_ETH_PHY_DP83848
+    esp_eth_phy_t *phy = esp_eth_phy_new_dp83848(&phy_config);
+#elif CONFIG_EXAMPLE_ETH_PHY_KSZ80XX
+    esp_eth_phy_t *phy = esp_eth_phy_new_ksz80xx(&phy_config);
+#endif
+    // Init Ethernet driver to default and install it
+    esp_eth_handle_t eth_handle = NULL;
+    esp_eth_config_t config = ETH_DEFAULT_CONFIG(mac, phy);
+    ESP_GOTO_ON_FALSE(esp_eth_driver_install(&config, &eth_handle) == ESP_OK, NULL,
+                        err, TAG, "Ethernet driver install failed");
+
+    if (mac_out != NULL) {
+        *mac_out = mac;
+    }
+    if (phy_out != NULL) {
+        *phy_out = phy;
+    }
+    return eth_handle;
+err:
+    if (eth_handle != NULL) {
+        esp_eth_driver_uninstall(eth_handle);
+    }
+    if (mac != NULL) {
+        mac->del(mac);
+    }
+    if (phy != NULL) {
+        phy->del(phy);
+    }
+    return ret;
+}
+#endif // CONFIG_EXAMPLE_USE_INTERNAL_ETHERNET
+
+#if CONFIG_EXAMPLE_USE_SPI_ETHERNET
+/**
+ * @brief SPI bus initialization (to be used by Ethernet SPI modules)
+ *
+ * @return
+ *          - ESP_OK on success
+ */
+static esp_err_t spi_bus_init(void)
+{
+    esp_err_t ret = ESP_OK;
+
+#if (CONFIG_EXAMPLE_ETH_SPI_INT0_GPIO >= 0) || (CONFIG_EXAMPLE_ETH_SPI_INT1_GPIO > 0)
+    // Install GPIO ISR handler to be able to service SPI Eth modules interrupts
+    ret = gpio_install_isr_service(0);
+    if (ret == ESP_OK) {
+        gpio_isr_svc_init_by_eth = true;
+    } else if (ret == ESP_ERR_INVALID_STATE) {
+        ESP_LOGW(TAG, "GPIO ISR handler has been already installed");
+        ret = ESP_OK; // ISR handler has been already installed so no issues
+    } else {
+        ESP_LOGE(TAG, "GPIO ISR handler install failed");
+        goto err;
+    }
+#endif
+
+    // Init SPI bus
+    spi_bus_config_t buscfg = {
+        .miso_io_num = CONFIG_EXAMPLE_ETH_SPI_MISO_GPIO,
+        .mosi_io_num = CONFIG_EXAMPLE_ETH_SPI_MOSI_GPIO,
+        .sclk_io_num = CONFIG_EXAMPLE_ETH_SPI_SCLK_GPIO,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+    };
+    ESP_GOTO_ON_ERROR(spi_bus_initialize(CONFIG_EXAMPLE_ETH_SPI_HOST, &buscfg, SPI_DMA_CH_AUTO),
+                        err, TAG, "SPI host #%d init failed", CONFIG_EXAMPLE_ETH_SPI_HOST);
+
+err:
+    return ret;
+}
+
+/**
+ * @brief Ethernet SPI modules initialization
+ *
+ * @param[in] spi_eth_module_config specific SPI Ethernet module configuration
+ * @param[out] mac_out optionally returns Ethernet MAC object
+ * @param[out] phy_out optionally returns Ethernet PHY object
+ * @return
+ *          - esp_eth_handle_t if init succeeded
+ *          - NULL if init failed
+ */
+static esp_eth_handle_t eth_init_spi(spi_eth_module_config_t *spi_eth_module_config, esp_eth_mac_t **mac_out, esp_eth_phy_t **phy_out)
+{
+    esp_eth_handle_t ret = NULL;
+
+    // Init common MAC and PHY configs to default
+    eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+    eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
+
+    // Update PHY config based on board specific configuration
+    phy_config.phy_addr = spi_eth_module_config->phy_addr;
+    phy_config.reset_gpio_num = spi_eth_module_config->phy_reset_gpio;
+
+    // Configure SPI interface for specific SPI module
+    spi_device_interface_config_t spi_devcfg = {
+        .mode = 0,
+        .clock_speed_hz = CONFIG_EXAMPLE_ETH_SPI_CLOCK_MHZ * 1000 * 1000,
+        .queue_size = 20,
+        .spics_io_num = spi_eth_module_config->spi_cs_gpio
+    };
+    // Init vendor specific MAC config to default, and create new SPI Ethernet MAC instance
+    // and new PHY instance based on board configuration
+#if CONFIG_EXAMPLE_USE_KSZ8851SNL
+    eth_ksz8851snl_config_t ksz8851snl_config = ETH_KSZ8851SNL_DEFAULT_CONFIG(CONFIG_EXAMPLE_ETH_SPI_HOST, &spi_devcfg);
+    ksz8851snl_config.int_gpio_num = spi_eth_module_config->int_gpio;
+    ksz8851snl_config.poll_period_ms = spi_eth_module_config->polling_ms;
+    esp_eth_mac_t *mac = esp_eth_mac_new_ksz8851snl(&ksz8851snl_config, &mac_config);
+    esp_eth_phy_t *phy = esp_eth_phy_new_ksz8851snl(&phy_config);
+#elif CONFIG_EXAMPLE_USE_DM9051
+    eth_dm9051_config_t dm9051_config = ETH_DM9051_DEFAULT_CONFIG(CONFIG_EXAMPLE_ETH_SPI_HOST, &spi_devcfg);
+    dm9051_config.int_gpio_num = spi_eth_module_config->int_gpio;
+    dm9051_config.poll_period_ms = spi_eth_module_config->polling_ms;
+    esp_eth_mac_t *mac = esp_eth_mac_new_dm9051(&dm9051_config, &mac_config);
+    esp_eth_phy_t *phy = esp_eth_phy_new_dm9051(&phy_config);
+#elif CONFIG_EXAMPLE_USE_W5500
+    eth_w5500_config_t w5500_config = ETH_W5500_DEFAULT_CONFIG(CONFIG_EXAMPLE_ETH_SPI_HOST, &spi_devcfg);
+    w5500_config.int_gpio_num = spi_eth_module_config->int_gpio;
+    w5500_config.poll_period_ms = spi_eth_module_config->polling_ms;
+    esp_eth_mac_t *mac = esp_eth_mac_new_w5500(&w5500_config, &mac_config);
+    esp_eth_phy_t *phy = esp_eth_phy_new_w5500(&phy_config);
+#endif //CONFIG_EXAMPLE_USE_W5500
+    // Init Ethernet driver to default and install it
+    esp_eth_handle_t eth_handle = NULL;
+    esp_eth_config_t eth_config_spi = ETH_DEFAULT_CONFIG(mac, phy);
+    ESP_GOTO_ON_FALSE(esp_eth_driver_install(&eth_config_spi, &eth_handle) == ESP_OK, NULL, err, TAG, "SPI Ethernet driver install failed");
+
+    // The SPI Ethernet module might not have a burned factory MAC address, we can set it manually.
+    if (spi_eth_module_config->mac_addr != NULL) {
+        ESP_GOTO_ON_FALSE(esp_eth_ioctl(eth_handle, ETH_CMD_S_MAC_ADDR, spi_eth_module_config->mac_addr) == ESP_OK,
+                                        NULL, err, TAG, "SPI Ethernet MAC address config failed");
+    }
+
+    if (mac_out != NULL) {
+        *mac_out = mac;
+    }
+    if (phy_out != NULL) {
+        *phy_out = phy;
+    }
+    return eth_handle;
+err:
+    if (eth_handle != NULL) {
+        esp_eth_driver_uninstall(eth_handle);
+    }
+    if (mac != NULL) {
+        mac->del(mac);
+    }
+    if (phy != NULL) {
+        phy->del(phy);
+    }
+    return ret;
+}
+#endif // CONFIG_EXAMPLE_USE_SPI_ETHERNET
+
+esp_err_t example_eth_init(esp_eth_handle_t *eth_handles_out[], uint8_t *eth_cnt_out)
+{
+    esp_err_t ret = ESP_OK;
+    esp_eth_handle_t *eth_handles = NULL;
+    uint8_t eth_cnt = 0;
+
+#if CONFIG_EXAMPLE_USE_INTERNAL_ETHERNET || CONFIG_EXAMPLE_USE_SPI_ETHERNET
+    ESP_GOTO_ON_FALSE(eth_handles_out != NULL && eth_cnt_out != NULL, ESP_ERR_INVALID_ARG,
+                        err, TAG, "invalid arguments: initialized handles array or number of interfaces");
+    eth_handles = calloc(SPI_ETHERNETS_NUM + INTERNAL_ETHERNETS_NUM, sizeof(esp_eth_handle_t));
+    ESP_GOTO_ON_FALSE(eth_handles != NULL, ESP_ERR_NO_MEM, err, TAG, "no memory");
+
+#if CONFIG_EXAMPLE_USE_INTERNAL_ETHERNET
+    eth_handles[eth_cnt] = eth_init_internal(NULL, NULL);
+    ESP_GOTO_ON_FALSE(eth_handles[eth_cnt], ESP_FAIL, err, TAG, "internal Ethernet init failed");
+    eth_cnt++;
+#endif //CONFIG_EXAMPLE_USE_INTERNAL_ETHERNET
+
+#if CONFIG_EXAMPLE_USE_SPI_ETHERNET
+    ESP_GOTO_ON_ERROR(spi_bus_init(), err, TAG, "SPI bus init failed");
+    // Init specific SPI Ethernet module configuration from Kconfig (CS GPIO, Interrupt GPIO, etc.)
+    spi_eth_module_config_t spi_eth_module_config[CONFIG_EXAMPLE_SPI_ETHERNETS_NUM] = { 0 };
+    INIT_SPI_ETH_MODULE_CONFIG(spi_eth_module_config, 0);
+    // The SPI Ethernet module(s) might not have a burned factory MAC address, hence use manually configured address(es).
+    // In this example, Locally Administered MAC address derived from ESP32x base MAC address is used.
+    // Note that Locally Administered OUI range should be used only when testing on a LAN under your control!
+    uint8_t base_mac_addr[ETH_ADDR_LEN];
+    ESP_GOTO_ON_ERROR(esp_efuse_mac_get_default(base_mac_addr), err, TAG, "get EFUSE MAC failed");
+    uint8_t local_mac_1[ETH_ADDR_LEN];
+    esp_derive_local_mac(local_mac_1, base_mac_addr);
+    spi_eth_module_config[0].mac_addr = local_mac_1;
+#if CONFIG_EXAMPLE_SPI_ETHERNETS_NUM > 1
+    INIT_SPI_ETH_MODULE_CONFIG(spi_eth_module_config, 1);
+    uint8_t local_mac_2[ETH_ADDR_LEN];
+    base_mac_addr[ETH_ADDR_LEN - 1] += 1;
+    esp_derive_local_mac(local_mac_2, base_mac_addr);
+    spi_eth_module_config[1].mac_addr = local_mac_2;
+#endif
+#if CONFIG_EXAMPLE_SPI_ETHERNETS_NUM > 2
+#error Maximum number of supported SPI Ethernet devices is currently limited to 2 by this example.
+#endif
+    for (int i = 0; i < CONFIG_EXAMPLE_SPI_ETHERNETS_NUM; i++) {
+        eth_handles[eth_cnt] = eth_init_spi(&spi_eth_module_config[i], NULL, NULL);
+        ESP_GOTO_ON_FALSE(eth_handles[eth_cnt], ESP_FAIL, err, TAG, "SPI Ethernet init failed");
+        eth_cnt++;
+    }
+#endif // CONFIG_EXAMPLE_USE_SPI_ETHERNET
+#else
+    ESP_LOGD(TAG, "no Ethernet device selected to init");
+#endif // CONFIG_EXAMPLE_USE_INTERNAL_ETHERNET || CONFIG_EXAMPLE_USE_SPI_ETHERNET
+    *eth_handles_out = eth_handles;
+    *eth_cnt_out = eth_cnt;
+
+    return ret;
+#if CONFIG_EXAMPLE_USE_INTERNAL_ETHERNET || CONFIG_EXAMPLE_USE_SPI_ETHERNET
+err:
+    free(eth_handles);
+    return ret;
+#endif
+}
+
+esp_err_t example_eth_deinit(esp_eth_handle_t *eth_handles, uint8_t eth_cnt)
+{
+    ESP_RETURN_ON_FALSE(eth_handles != NULL, ESP_ERR_INVALID_ARG, TAG, "array of Ethernet handles cannot be NULL");
+    for (int i = 0; i < eth_cnt; i++) {
+        esp_eth_mac_t *mac = NULL;
+        esp_eth_phy_t *phy = NULL;
+        if (eth_handles[i] != NULL) {
+            esp_eth_get_mac_instance(eth_handles[i], &mac);
+            esp_eth_get_phy_instance(eth_handles[i], &phy);
+            ESP_RETURN_ON_ERROR(esp_eth_driver_uninstall(eth_handles[i]), TAG, "Ethernet %p uninstall failed", eth_handles[i]);
+        }
+        if (mac != NULL) {
+            mac->del(mac);
+        }
+        if (phy != NULL) {
+            phy->del(phy);
+        }
+    }
+#if CONFIG_EXAMPLE_USE_SPI_ETHERNET
+    spi_bus_free(CONFIG_EXAMPLE_ETH_SPI_HOST);
+#if (CONFIG_EXAMPLE_ETH_SPI_INT0_GPIO >= 0) || (CONFIG_EXAMPLE_ETH_SPI_INT1_GPIO > 0)
+    // We installed the GPIO ISR service so let's uninstall it too.
+    // BE CAREFUL HERE though since the service might be used by other functionality!
+    if (gpio_isr_svc_init_by_eth) {
+        ESP_LOGW(TAG, "uninstalling GPIO ISR service!");
+        gpio_uninstall_isr_service();
+    }
+#endif
+#endif //CONFIG_EXAMPLE_USE_SPI_ETHERNET
+    free(eth_handles);
+    return ESP_OK;
+}

--- a/platform/ethernet/components/ethernet_init/ethernet_init.h
+++ b/platform/ethernet/components/ethernet_init/ethernet_init.h
@@ -1,0 +1,47 @@
+/*
+ * NOTE:
+ *   This file is copied from esp-idf examples as the below, and modified for usage of mros2-esp32.
+ *   https://github.com/espressif/esp-idf/blob/master/examples/ethernet/basic/components/ethernet_init/ethernet_init.c
+ *   Therefore, mROS-base org inherits the Public Domain (or CC0) LICENCE for this file from the original file.
+ */
+/*
+ * SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Unlicense OR CC0-1.0
+ */
+#pragma once
+
+#include "esp_eth_driver.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize Ethernet driver based on Espressif IoT Development Framework Configuration
+ *
+ * @param[out] eth_handles_out array of initialized Ethernet driver handles
+ * @param[out] eth_cnt_out number of initialized Ethernets
+ * @return
+ *          - ESP_OK on success
+ *          - ESP_ERR_INVALID_ARG when passed invalid pointers
+ *          - ESP_ERR_NO_MEM when there is no memory to allocate for Ethernet driver handles array
+ *          - ESP_FAIL on any other failure
+ */
+esp_err_t example_eth_init(esp_eth_handle_t *eth_handles_out[], uint8_t *eth_cnt_out);
+
+/**
+ * @brief De-initialize array of Ethernet drivers
+ * @note All Ethernet drivers in the array must be stopped prior calling this function.
+ *
+ * @param[in] eth_handles array of Ethernet drivers to be de-initialized
+ * @param[in] eth_cnt number of Ethernets drivers to be de-initialized
+ * @return
+ *          - ESP_OK on success
+ *          - ESP_ERR_INVALID_ARG when passed invalid pointers
+ */
+esp_err_t example_eth_deinit(esp_eth_handle_t *eth_handles, uint8_t eth_cnt);
+
+#ifdef __cplusplus
+}
+#endif

--- a/platform/ethernet/main/CMakeLists.txt
+++ b/platform/ethernet/main/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "ethernet_example_main.c"
+                       PRIV_REQUIRES esp_netif esp_eth ethernet_init
+                       INCLUDE_DIRS ".")

--- a/platform/ethernet/main/ethernet_example_main.c
+++ b/platform/ethernet/main/ethernet_example_main.c
@@ -1,0 +1,170 @@
+/*
+ * NOTE:
+ *   This file is copied from esp-idf examples as the below, and modified for usage of mros2-esp32.
+ *   https://github.com/espressif/esp-idf/blob/master/examples/ethernet/basic/main/ethernet_example_main.c
+ *   Therefore, mROS-base org inherits the Public Domain (or CC0) LICENCE for this file from the original file.
+ */
+/* Ethernet Basic Example
+
+   This example code is in the Public Domain (or CC0 licensed, at your option.)
+
+   Unless required by applicable law or agreed to in writing, this
+   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+   CONDITIONS OF ANY KIND, either express or implied.
+*/
+#include <stdio.h>
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_netif.h"
+#include "esp_eth.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "ethernet_init.h"
+#include "sdkconfig.h"
+#include "ethernet_example_main.h"
+
+static EventGroupHandle_t s_ethernet_event_group;
+static const char *TAG = "eth_example";
+
+/* keep IP address obtained in event_handler */
+static uint32_t mros2_ip_addr_eth;
+
+/** Event handler for Ethernet events */
+static void eth_event_handler(void *arg, esp_event_base_t event_base,
+                              int32_t event_id, void *event_data)
+{
+    uint8_t mac_addr[6] = {0};
+    /* we can get the ethernet driver handle from event data */
+    esp_eth_handle_t eth_handle = *(esp_eth_handle_t *)event_data;
+
+    switch (event_id) {
+    case ETHERNET_EVENT_CONNECTED:
+        esp_eth_ioctl(eth_handle, ETH_CMD_G_MAC_ADDR, mac_addr);
+        ESP_LOGI(TAG, "Ethernet Link Up");
+        ESP_LOGI(TAG, "Ethernet HW Addr %02x:%02x:%02x:%02x:%02x:%02x",
+                 mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+        break;
+    case ETHERNET_EVENT_DISCONNECTED:
+        ESP_LOGI(TAG, "Ethernet Link Down");
+        xEventGroupSetBits(s_ethernet_event_group, ETHERNET_FAIL_BIT);        
+        break;
+    case ETHERNET_EVENT_START:
+        ESP_LOGI(TAG, "Ethernet Started");
+        break;
+    case ETHERNET_EVENT_STOP:
+        ESP_LOGI(TAG, "Ethernet Stopped");
+        xEventGroupSetBits(s_ethernet_event_group, ETHERNET_FAIL_BIT);
+        break;
+    default:
+        break;
+    }
+}
+
+/** Event handler for IP_EVENT_ETH_GOT_IP */
+static void got_ip_event_handler(void *arg, esp_event_base_t event_base,
+                                 int32_t event_id, void *event_data)
+{
+    ip_event_got_ip_t *event = (ip_event_got_ip_t *) event_data;
+    const esp_netif_ip_info_t *ip_info = &event->ip_info;
+
+    ESP_LOGI(TAG, "Ethernet Got IP Address");
+    ESP_LOGI(TAG, "~~~~~~~~~~~");
+    ESP_LOGI(TAG, "ETHIP:" IPSTR, IP2STR(&ip_info->ip));
+    ESP_LOGI(TAG, "ETHMASK:" IPSTR, IP2STR(&ip_info->netmask));
+    ESP_LOGI(TAG, "ETHGW:" IPSTR, IP2STR(&ip_info->gw));
+    ESP_LOGI(TAG, "~~~~~~~~~~~");
+    
+    xEventGroupSetBits(s_ethernet_event_group, ETHERNET_CONNECTED_BIT);
+    mros2_ip_addr_eth = ip_info->ip.addr;
+}
+
+void init_ethernet(void)
+{
+    s_ethernet_event_group = xEventGroupCreate();
+
+    // Initialize Ethernet driver
+    uint8_t eth_port_cnt = 0;
+    esp_eth_handle_t *eth_handles;
+    ESP_ERROR_CHECK(example_eth_init(&eth_handles, &eth_port_cnt));
+
+    // Initialize TCP/IP network interface aka the esp-netif (should be called only once in application)
+    ESP_ERROR_CHECK(esp_netif_init());
+    // Create default event loop that running in background
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+
+    esp_netif_t *eth_netifs[eth_port_cnt];
+    esp_eth_netif_glue_handle_t eth_netif_glues[eth_port_cnt];
+
+    // Create instance(s) of esp-netif for Ethernet(s)
+    if (eth_port_cnt == 1) {
+        // Use ESP_NETIF_DEFAULT_ETH when just one Ethernet interface is used and you don't need to modify
+        // default esp-netif configuration parameters.
+        esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
+        eth_netifs[0] = esp_netif_new(&cfg);
+        eth_netif_glues[0] = esp_eth_new_netif_glue(eth_handles[0]);
+        // Attach Ethernet driver to TCP/IP stack
+        ESP_ERROR_CHECK(esp_netif_attach(eth_netifs[0], eth_netif_glues[0]));
+    } else {
+        // Use ESP_NETIF_INHERENT_DEFAULT_ETH when multiple Ethernet interfaces are used and so you need to modify
+        // esp-netif configuration parameters for each interface (name, priority, etc.).
+        esp_netif_inherent_config_t esp_netif_config = ESP_NETIF_INHERENT_DEFAULT_ETH();
+        esp_netif_config_t cfg_spi = {
+            .base = &esp_netif_config,
+            .stack = ESP_NETIF_NETSTACK_DEFAULT_ETH
+        };
+        char if_key_str[10];
+        char if_desc_str[10];
+        char num_str[3];
+        for (int i = 0; i < eth_port_cnt; i++) {
+            itoa(i, num_str, 10);
+            strcat(strcpy(if_key_str, "ETH_"), num_str);
+            strcat(strcpy(if_desc_str, "eth"), num_str);
+            esp_netif_config.if_key = if_key_str;
+            esp_netif_config.if_desc = if_desc_str;
+            esp_netif_config.route_prio -= i*5;
+            eth_netifs[i] = esp_netif_new(&cfg_spi);
+            eth_netif_glues[i] = esp_eth_new_netif_glue(eth_handles[0]);
+            // Attach Ethernet driver to TCP/IP stack
+            ESP_ERROR_CHECK(esp_netif_attach(eth_netifs[i], eth_netif_glues[i]));
+        }
+    }
+
+    // Register user defined event handers
+    ESP_ERROR_CHECK(esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID, &eth_event_handler, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &got_ip_event_handler, NULL));
+
+    // Start Ethernet driver state machine
+    for (int i = 0; i < eth_port_cnt; i++) {
+        ESP_ERROR_CHECK(esp_eth_start(eth_handles[i]));
+    }
+    /* Waiting until either the connection is established (WIFI_CONNECTED_BIT) or connection failed for the maximum
+     * number of re-tries (WIFI_FAIL_BIT). The bits are set by event_handler() (see above) */
+    EventBits_t bits = xEventGroupWaitBits(s_ethernet_event_group,
+                                   ETHERNET_CONNECTED_BIT | ETHERNET_FAIL_BIT,
+                                   pdFALSE,
+                                   pdFALSE,
+                                   portMAX_DELAY);
+
+#if CONFIG_EXAMPLE_ETH_DEINIT_AFTER_S >= 0
+    // For demonstration purposes, wait and then deinit Ethernet network
+    vTaskDelay(pdMS_TO_TICKS(CONFIG_EXAMPLE_ETH_DEINIT_AFTER_S * 1000));
+    ESP_LOGI(TAG, "stop and deinitialize Ethernet network...");
+    // Stop Ethernet driver state machine and destroy netif
+    for (int i = 0; i < eth_port_cnt; i++) {
+        ESP_ERROR_CHECK(esp_eth_stop(eth_handles[i]));
+        ESP_ERROR_CHECK(esp_eth_del_netif_glue(eth_netif_glues[i]));
+        esp_netif_destroy(eth_netifs[i]);
+    }
+    esp_netif_deinit();
+    ESP_ERROR_CHECK(example_eth_deinit(eth_handles, eth_port_cnt));
+    ESP_ERROR_CHECK(esp_event_handler_unregister(IP_EVENT, IP_EVENT_ETH_GOT_IP, got_ip_event_handler));
+    ESP_ERROR_CHECK(esp_event_handler_unregister(ETH_EVENT, ESP_EVENT_ANY_ID, eth_event_handler));
+    ESP_ERROR_CHECK(esp_event_loop_delete_default());
+#endif // EXAMPLE_ETH_DEINIT_AFTER_S > 0
+}
+
+uint32_t get_mros2_ip_addr_eth(void)
+{
+    return mros2_ip_addr_eth;
+}

--- a/platform/ethernet/main/ethernet_example_main.h
+++ b/platform/ethernet/main/ethernet_example_main.h
@@ -1,0 +1,24 @@
+/*
+ * NOTE:
+ *   This file is copied from esp-idf examples as the below, and modified for usage of mros2-esp32.
+ *   https://github.com/espressif/esp-idf/blob/master/examples/ethernet/basic/main/ethernet_example_main.c
+ *   Therefore, mROS-base org inherits the Public Domain (or CC0) LICENCE for this file from the original file.
+ */
+
+#define ETHERNET_CONNECTED_BIT BIT0
+#define ETHERNET_FAIL_BIT BIT1
+
+/*
+ * Caution:
+ *   We have not tested the operation using STATIC_IP setting yet.
+ *   So you may not un-comment the below line to use DHCP setting
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern void init_ethernet(void);
+uint32_t get_mros2_ip_addr_eth(void);
+#ifdef __cplusplus
+}
+#endif

--- a/platform/mros2-platform.cpp
+++ b/platform/mros2-platform.cpp
@@ -23,17 +23,29 @@
 
 #include "cmsis_os.h"
 #include "wifi.h"
-
+#include "ethernet_example_main.h"
 
 /*
  *  Setup network I/F
  */
 extern "C" esp_err_t mros2_platform_network_connect(void)
 {
+#ifdef CONFIG_MROS2_ESP32_NETIF_WIFI
   init_wifi();
+#elif CONFIG_MROS2_ESP32_NETIF_ETH_SPI
+  init_ethernet();
+#else
+  init_wifi();
+#endif
   osKernelStart();
 
   /* get mros2 IP address and set it to RTPS */
+#ifdef CONFIG_MROS2_ESP32_NETIF_WIFI
   uint32_t ipaddr = get_mros2_ip_addr();
+#elif CONFIG_MROS2_ESP32_NETIF_ETH_SPI
+  uint32_t ipaddr = get_mros2_ip_addr_eth();
+#else
+  uint32_t ipaddr = get_mros2_ip_addr();
+#endif
   return mros2_setIPAddrRTPS(ipaddr);
 }

--- a/workspace/echoback_string/main/Kconfig.projbuild
+++ b/workspace/echoback_string/main/Kconfig.projbuild
@@ -1,0 +1,327 @@
+menu "mros2-esp32 network interface"
+    choice
+        prompt "mros2-esp32 network interface"
+	    default MROS2_ESP32_NETIF_WIFI
+            config MROS2_ESP32_NETIF_WIFI
+                bool "WiFi"
+            config MROS2_ESP32_NETIF_ETH_SPI
+                bool "Ethernet-SPI"
+	endchoice
+endmenu
+menu "Example Configuration"
+    config EXAMPLE_ETH_DEINIT_AFTER_S
+        int "Stop and deinit Ethernet after elapsing number of secs"
+        range -1 300
+        default -1
+        help
+            This option is for demonstration purposes only to demonstrate deinitialization of the Ethernet driver.
+            Set to -1 to not deinitialize.
+endmenu
+menu "Example Ethernet Configuration"
+
+    orsource "$IDF_PATH/examples/common_components/env_caps/$IDF_TARGET/Kconfig.env_caps"
+
+    config EXAMPLE_USE_INTERNAL_ETHERNET
+        depends on SOC_EMAC_SUPPORTED
+        select ETH_USE_ESP32_EMAC
+        default y
+        bool "Internal EMAC"
+        help
+            Use internal Ethernet MAC controller.
+
+    if EXAMPLE_USE_INTERNAL_ETHERNET
+        choice EXAMPLE_ETH_PHY_MODEL
+            prompt "Ethernet PHY Device"
+            default EXAMPLE_ETH_PHY_IP101
+            help
+                Select the Ethernet PHY device to use in the example.
+
+            config EXAMPLE_ETH_PHY_GENERIC
+                bool "Generic 802.3 PHY"
+                help
+                    Any Ethernet PHY chip compliant with IEEE 802.3 can be used. However, while
+                    basic functionality should always work, some specific features might be limited,
+                    even if the PHY meets IEEE 802.3 standard. A typical example is loopback
+                    functionality, where certain PHYs may require setting a specific speed mode to
+                    operate correctly.
+
+            config EXAMPLE_ETH_PHY_IP101
+                bool "IP101"
+                help
+                    IP101 is a single port 10/100 MII/RMII/TP/Fiber Fast Ethernet Transceiver.
+                    Goto http://www.icplus.com.tw/pp-IP101G.html for more information about it.
+
+            config EXAMPLE_ETH_PHY_RTL8201
+                bool "RTL8201/SR8201"
+                help
+                    RTL8201F/SR8201F is a single port 10/100Mb Ethernet Transceiver with auto MDIX.
+                    Goto http://www.corechip-sz.com/productsview.asp?id=22 for more information about it.
+
+            config EXAMPLE_ETH_PHY_LAN87XX
+                bool "LAN87xx"
+                help
+                    Below chips are supported:
+                    LAN8710A is a small footprint MII/RMII 10/100 Ethernet Transceiver with HP Auto-MDIX and
+                        flexPWR® Technology.
+                    LAN8720A is a small footprint RMII 10/100 Ethernet Transceiver with HP Auto-MDIX Support.
+                    LAN8740A/LAN8741A is a small footprint MII/RMII 10/100 Energy Efficient Ethernet Transceiver
+                        with HP Auto-MDIX and flexPWR® Technology.
+                    LAN8742A is a small footprint RMII 10/100 Ethernet Transceiver with HP Auto-MDIX and
+                        flexPWR® Technology.
+                    Goto https://www.microchip.com for more information about them.
+
+            config EXAMPLE_ETH_PHY_DP83848
+                bool "DP83848"
+                help
+                    DP83848 is a single port 10/100Mb/s Ethernet Physical Layer Transceiver.
+                    Goto http://www.ti.com/product/DP83848J for more information about it.
+
+            config EXAMPLE_ETH_PHY_KSZ80XX
+                bool "KSZ80xx"
+                help
+                    With the KSZ80xx series, Microchip offers single-chip 10BASE-T/100BASE-TX
+                    Ethernet Physical Layer Transceivers (PHY).
+                    The following chips are supported: KSZ8001, KSZ8021, KSZ8031, KSZ8041,
+                        KSZ8051, KSZ8061, KSZ8081, KSZ8091
+                    Goto https://www.microchip.com for more information about them.
+        endchoice # EXAMPLE_ETH_PHY_MODEL
+
+        config EXAMPLE_ETH_MDC_GPIO
+            int "SMI MDC GPIO number"
+            range ENV_GPIO_RANGE_MIN ENV_GPIO_OUT_RANGE_MAX
+            default 23 if IDF_TARGET_ESP32
+            default 31 if IDF_TARGET_ESP32P4
+            help
+                Set the GPIO number used by SMI MDC.
+
+        config EXAMPLE_ETH_MDIO_GPIO
+            int "SMI MDIO GPIO number"
+            range ENV_GPIO_RANGE_MIN ENV_GPIO_OUT_RANGE_MAX
+            default 18 if IDF_TARGET_ESP32
+            default 52 if IDF_TARGET_ESP32P4
+            help
+                Set the GPIO number used by SMI MDIO.
+
+        config EXAMPLE_ETH_PHY_RST_GPIO
+            int "PHY Reset GPIO number"
+            range -1 ENV_GPIO_OUT_RANGE_MAX
+            default 5 if IDF_TARGET_ESP32
+            default 51 if IDF_TARGET_ESP32P4
+            help
+                Set the GPIO number used to reset PHY chip.
+                Set to -1 to disable PHY chip hardware reset.
+
+        config EXAMPLE_ETH_PHY_ADDR
+            int "PHY Address"
+            range -1 31
+            default 1
+            help
+                Set PHY address according your board schematic.
+                Set to -1 to driver find the PHY address automatically.
+    endif # EXAMPLE_USE_INTERNAL_ETHERNET
+
+    config EXAMPLE_USE_SPI_ETHERNET
+        bool "SPI Ethernet"
+        default n
+        select ETH_USE_SPI_ETHERNET
+        help
+            Use external SPI-Ethernet module(s).
+
+    if EXAMPLE_USE_SPI_ETHERNET
+        config EXAMPLE_SPI_ETHERNETS_NUM
+            int "Number of SPI Ethernet modules to use at a time"
+            range 1 2
+            default 1
+            help
+                Set the number of SPI Ethernet modules you want to use at a time. Multiple SPI modules can be connected
+                to one SPI interface and can be separately accessed based on state of associated Chip Select (CS).
+
+        choice EXAMPLE_ETHERNET_TYPE_SPI
+            prompt "Ethernet SPI"
+            default EXAMPLE_USE_W5500
+            help
+                Select which kind of Ethernet will be used in the example.
+
+            config EXAMPLE_USE_DM9051
+                bool "DM9051 Module"
+                select ETH_SPI_ETHERNET_DM9051
+                help
+                    Select external SPI-Ethernet module (DM9051).
+
+            config EXAMPLE_USE_KSZ8851SNL
+                bool "KSZ8851SNL Module"
+                select ETH_SPI_ETHERNET_KSZ8851SNL
+                help
+                    Select external SPI-Ethernet module (KSZ8851SNL).
+
+            config EXAMPLE_USE_W5500
+                bool "W5500 Module"
+                select ETH_SPI_ETHERNET_W5500
+                help
+                    Select external SPI-Ethernet module (W5500).
+        endchoice
+
+        config EXAMPLE_ETH_SPI_HOST
+            int "SPI Host Number"
+            range 0 2
+            default 1
+            help
+                Set the SPI host used to communicate with the SPI Ethernet Controller.
+
+        config EXAMPLE_ETH_SPI_SCLK_GPIO
+            int "SPI SCLK GPIO number"
+            range ENV_GPIO_RANGE_MIN ENV_GPIO_OUT_RANGE_MAX
+            default 14 if IDF_TARGET_ESP32
+            default 12 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+            default 6 if IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32C6 || IDF_TARGET_ESP32C61
+            default 4 if IDF_TARGET_ESP32H2
+            default 33 if IDF_TARGET_ESP32P4
+            default 8 if IDF_TARGET_ESP32C5
+            help
+                Set the GPIO number used by SPI SCLK.
+
+        config EXAMPLE_ETH_SPI_MOSI_GPIO
+            int "SPI MOSI GPIO number"
+            range ENV_GPIO_RANGE_MIN ENV_GPIO_OUT_RANGE_MAX
+            default 13 if IDF_TARGET_ESP32
+            default 11 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+            default 7 if IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32C6 || IDF_TARGET_ESP32C61
+            default 5 if IDF_TARGET_ESP32H2
+            default 32 if IDF_TARGET_ESP32P4
+            default 10 if IDF_TARGET_ESP32C5
+            help
+                Set the GPIO number used by SPI MOSI.
+
+        config EXAMPLE_ETH_SPI_MISO_GPIO
+            int "SPI MISO GPIO number"
+            range ENV_GPIO_RANGE_MIN ENV_GPIO_IN_RANGE_MAX
+            default 12 if IDF_TARGET_ESP32
+            default 13 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+            default 2 if IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32C6 || IDF_TARGET_ESP32C61
+            default 0 if IDF_TARGET_ESP32H2
+            default 24 if IDF_TARGET_ESP32P4
+            default 9 if IDF_TARGET_ESP32C5
+            help
+                Set the GPIO number used by SPI MISO.
+
+        config EXAMPLE_ETH_SPI_CLOCK_MHZ
+            int "SPI clock speed (MHz)"
+            range 5 80
+            default 16
+            help
+                Set the clock speed (MHz) of SPI interface.
+
+        config EXAMPLE_ETH_SPI_CS0_GPIO
+            int "SPI CS0 GPIO number for SPI Ethernet module #1"
+            range ENV_GPIO_RANGE_MIN ENV_GPIO_OUT_RANGE_MAX
+            default 15 if IDF_TARGET_ESP32
+            default 10 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32C2
+            default 3 if IDF_TARGET_ESP32C6 || IDF_TARGET_ESP32C5 || IDF_TARGET_ESP32C61
+            default 1 if IDF_TARGET_ESP32H2
+            default 21 if IDF_TARGET_ESP32P4
+            help
+                Set the GPIO number used by SPI CS0, i.e. Chip Select associated with the first SPI Eth module).
+
+        config EXAMPLE_ETH_SPI_CS1_GPIO
+            depends on EXAMPLE_SPI_ETHERNETS_NUM > 1
+            int "SPI CS1 GPIO number for SPI Ethernet module #2"
+            range ENV_GPIO_RANGE_MIN ENV_GPIO_OUT_RANGE_MAX
+            default 32 if IDF_TARGET_ESP32
+            default 7 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3
+            default 8 if IDF_TARGET_ESP32C3
+            default 21 if IDF_TARGET_ESP32C6
+            default 3 if IDF_TARGET_ESP32C2
+            default 11 if IDF_TARGET_ESP32H2
+            default 23 if IDF_TARGET_ESP32P4 || IDF_TARGET_ESP32C61
+            default 1 if IDF_TARGET_ESP32C5
+            help
+                Set the GPIO number used by SPI CS1, i.e. Chip Select associated with the second SPI Eth module.
+
+        config EXAMPLE_ETH_SPI_INT0_GPIO
+            int "Interrupt GPIO number SPI Ethernet module #1"
+            range -1 ENV_GPIO_IN_RANGE_MAX
+            default 4 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32S3
+            default 4 if IDF_TARGET_ESP32C2 || IDF_TARGET_ESP32C6 || IDF_TARGET_ESP32C5
+            default 10 if IDF_TARGET_ESP32H2
+            default 48 if IDF_TARGET_ESP32P4
+            default 0 if IDF_TARGET_ESP32C61
+            help
+                Set the GPIO number used by the first SPI Ethernet module interrupt line.
+                Set -1 to use SPI Ethernet module in polling mode.
+
+        config EXAMPLE_ETH_SPI_INT1_GPIO
+            depends on EXAMPLE_SPI_ETHERNETS_NUM > 1
+            int "Interrupt GPIO number SPI Ethernet module #2"
+            range -1 ENV_GPIO_IN_RANGE_MAX
+            default 33 if IDF_TARGET_ESP32
+            default 5 if IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32C3 || IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32C2
+            default 5 if IDF_TARGET_ESP32C6 || IDF_TARGET_ESP32C5
+            default 9 if IDF_TARGET_ESP32H2
+            default 47 if IDF_TARGET_ESP32P4
+            default 1 if IDF_TARGET_ESP32C61
+            help
+                Set the GPIO number used by the second SPI Ethernet module interrupt line.
+                Set -1 to use SPI Ethernet module in polling mode.
+
+        config EXAMPLE_ETH_SPI_POLLING0_MS_VAL
+            depends on EXAMPLE_ETH_SPI_INT0_GPIO < 0
+            int "Polling period in msec of SPI Ethernet Module #1"
+            default 10
+            help
+                Set SPI Ethernet module polling period.
+
+        config EXAMPLE_ETH_SPI_POLLING1_MS_VAL
+            depends on EXAMPLE_SPI_ETHERNETS_NUM > 1 && EXAMPLE_ETH_SPI_INT1_GPIO < 0
+            int "Polling period in msec of SPI Ethernet Module #2"
+            default 10
+            help
+                Set SPI Ethernet module polling period.
+
+        # Hidden variable to ensure that polling period option is visible only when interrupt is set disabled and
+        # it is set to known value (0) when interrupt is enabled at the same time.
+        config EXAMPLE_ETH_SPI_POLLING0_MS
+            int
+            default EXAMPLE_ETH_SPI_POLLING0_MS_VAL if EXAMPLE_ETH_SPI_POLLING0_MS_VAL > 0
+            default 0
+
+        # Hidden variable to ensure that polling period option is visible only when interrupt is set disabled and
+        # it is set to known value (0) when interrupt is enabled at the same time.
+        config EXAMPLE_ETH_SPI_POLLING1_MS
+            depends on EXAMPLE_SPI_ETHERNETS_NUM > 1
+            int
+            default EXAMPLE_ETH_SPI_POLLING1_MS_VAL if EXAMPLE_ETH_SPI_POLLING1_MS_VAL > 0
+            default 0
+
+        config EXAMPLE_ETH_SPI_PHY_RST0_GPIO
+            int "PHY Reset GPIO number of SPI Ethernet Module #1"
+            range -1 ENV_GPIO_OUT_RANGE_MAX
+            default -1
+            help
+                Set the GPIO number used to reset PHY chip on the first SPI Ethernet module.
+                Set to -1 to disable PHY chip hardware reset.
+
+        config EXAMPLE_ETH_SPI_PHY_RST1_GPIO
+            depends on EXAMPLE_SPI_ETHERNETS_NUM > 1
+            int "PHY Reset GPIO number of SPI Ethernet Module #2"
+            range -1 ENV_GPIO_OUT_RANGE_MAX
+            default -1
+            help
+                Set the GPIO number used to reset PHY chip on the second SPI Ethernet module.
+                Set to -1 to disable PHY chip hardware reset.
+
+        config EXAMPLE_ETH_SPI_PHY_ADDR0
+            int "PHY Address of SPI Ethernet Module #1"
+            range 0 31
+            default 1
+            help
+                Set the first SPI Ethernet module PHY address according your board schematic.
+
+        config EXAMPLE_ETH_SPI_PHY_ADDR1
+            depends on EXAMPLE_SPI_ETHERNETS_NUM > 1
+            int "PHY Address of SPI Ethernet Module #2"
+            range 0 31
+            default 1
+            help
+                Set the second SPI Ethernet module PHY address according your board schematic.
+    endif # EXAMPLE_USE_SPI_ETHERNET
+endmenu


### PR DESCRIPTION
We would like to make a proposal for Ethernet support.
Could you please delete the following file: platform/ethernet/CMakeLists.txt? I realize I was wrong.
I am merging three Kconfig.projbuild files. [margefile.zip](https://github.com/user-attachments/files/18240161/margefile.zip)
```
#!/bin/bash
cat ./mros2esp32-network-select.txt \
    ~/esp/esp-idf/examples/ethernet/basic/main/Kconfig.projbuild \
    ~/esp/esp-idf/examples/ethernet/basic/components/ethernet_init/Kconfig.projbuild \
    > ./Kconfig.projbuild
if [ $? -eq 0 ]; then
    echo "Kconfig.projbuild has been generated. Merging the files."
else
    echo "Error: Failed to merge the files."
fi
```
We will copy the Kconfig.projbuild file. example ~/mros2-esp32/workspace/echoback_string/main/
```
workspace
├── echoback_string
│   ├── CMakeLists.txt
│   └── main
│       ├── CMakeLists.txt
│       ├── echoback_string.cpp
│       └── Kconfig.projbuild   # add copy
├── echoreply_string
├── m5stack_sample
├── pub_float32
├── pub_image
├── pub_long_string_sub_crc
├── pub_twist
├── sub_pose
└── sub_uint16
```
[Handling of the Kconfig.projbuild during Ethernet support in the mros2-esp32 project #26](https://github.com/mROS-base/mros2-esp32/issues/26)